### PR TITLE
Remove authentication from toggling

### DIFF
--- a/ospi.py
+++ b/ospi.py
@@ -747,7 +747,6 @@ class get_station:
 class set_station:
     """turn a station (valve/zone) on=1 or off=0 in manual mode."""
     def GET(self, nst, t=None): # nst = station number, status, optional duration
-        verifyLogin()
         nstlst = [int(i) for i in re.split('=|&t=', nst)]
         if len(nstlst) == 2:
             nstlst.append(0)


### PR DESCRIPTION
Although I agree authentication is needed here it breaks the URL authentication method since the URL scheme is non-standard (this is due to the Arduino method and not OSPi specific).

In the urls.py, a regex is used to match the station toggling which makes it difficult to add a third parameter (password) without making things complex. For now, this falls back to the previous method and is inline with the Arduino firmware. I think in the long term a correct syntax should be adopted (ex: /cm?sn1=1&t=0) which allows proper data input parsing.

Thanks
