### PR TITLE
init gv.snames for use by plugins

### DIFF
--- a/ospi.py
+++ b/ospi.py
@@ -446,6 +446,7 @@ gv.lrun=[0,0,0,0] #station index, program number, duration, end time (Used in UI
 
 gv.scount = 0 # Station count, used in set station to track on stations with master association.
 
+gv.snames = data('snames') # initialize station names to be used by plugins
 
   ########################
   #### Login Handling ####


### PR DESCRIPTION
This change initializes the global variable gv.snames during the first run in order for it to be used by plug-ins.
