### PR TITLE
Mobile App: Restore missing set_password class

### DIFF
--- a/plugins/mobile_app.py
+++ b/plugins/mobile_app.py
@@ -4,7 +4,7 @@ import datetime
 import string
 import calendar
 
-from helpers import get_cpu_temp, check_login
+from helpers import get_cpu_temp, check_login, password_hash
 import web
 import gv  # Gain access to ospi's settings
 from urls import urls  # Gain access to ospi's URL list
@@ -182,6 +182,29 @@ class get_logs(ProtectedPage):  # /jl
             return records
         except IOError:
             return []
+
+class set_password():
+    """Save changes to device password"""
+    def GET(self):
+        qdict = web.input()
+        web.header('Access-Control-Allow-Origin', '*')
+        web.header('Content-Type', 'application/json')
+        web.header('Cache-Control', 'no-cache')
+
+        if not(qdict.has_key('pw')) or not(qdict.has_key('npw')) or not(qdict.has_key('cpw')):
+            return json.dumps({"result":3})
+
+        if password_hash(qdict['pw'], gv.sd['salt']) == gv.sd['password']:
+            if qdict['npw'] == "":
+                return json.dumps({"result":3})
+            elif qdict['cpw'] !='' and qdict['cpw'] == qdict['npw']:
+                gv.sd['password'] = password_hash(qdict['npw'], gv.sd['salt'])
+            else:
+                return json.dumps({"result":4})
+        else:
+            return json.dumps({"result":2})
+
+        return json.dumps({"result":1})
 
 def utc_to_local(utc_dt):
     # get integer timestamp to avoid precision lost


### PR DESCRIPTION
No idea how this keeps happening but an entire class went missing from my plugin. I traced this back to Sept 12 around the time Rimco was making changes. CVS is supposed to prevent these things when used correctly but unfortunately its very muddled.
