### PR TITLE
Escape html quoting to allow sprinkler names with single quotes

### DIFF
--- a/templates/options.html
+++ b/templates/options.html
@@ -93,7 +93,7 @@ $code:
             if datatype == "boolean":
                 output += "<input name='o" + name + "' type='checkbox' " + ("checked" if value>0 else "") + ">\n"
             elif datatype == "string":
-                output += "<input name='o" + name + "' type='text' size='31' maxlength='31' value='" + value + "'>\n"
+                output += "<input name='o" + name + "' type='text' size='31' maxlength='31' value=\"" + value + "\">\n"
             elif datatype == "password":
                 output += "<input name='" + name + "' type='password' size='31' maxlength='31'><span class='inputError' id='error" + name + "'></span>\n"
             elif name == "lang":


### PR DESCRIPTION
Dan,

This is a first test to see if a change I made can be pulled into your mainline.  Basically when a sprinkler name contained a single quote, when you revisited the options page, only the string before the quote would be displayed and then if you saved options, you effectively modified your sprinkler name.
