### PR TITLE
Support plugins to have global data found in gv.plugin_data[key] wher…

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ UPDATES - Note: This project, formally OSPi, has been renamed to SIP
 ===========
 
 ***********
+August 15 2015
+----------
+(Brian)
+1. Add gv.output_srvals and a gv.output_srvals_lock, so that threads can get a consistent state of stations currently running
+2. Add gv.plugin_data which is a dictionary (index by plugin webpage base) to hold data associated with a plugin  
+3. Add gv.nowt to have a struct time of the current time
+
+***********
 August 9 2015
 ----------
 (Brian)  

--- a/gpio_pins.py
+++ b/gpio_pins.py
@@ -42,7 +42,6 @@ try:
 except NameError:
     pass
 
-
 def setup_pins():
     """
     Define and setup GPIO pins for shift register operation
@@ -127,7 +126,9 @@ def setShiftRegister(srvals):
 def set_output():
     """Activate triacs according to shift register state."""
 
-    disableShiftRegisterOutput()
-    setShiftRegister(gv.srvals)  # gv.srvals stores shift register state
-    enableShiftRegisterOutput()
-    zone_change.send()
+    with gv.output_srvals_lock:
+        gv.output_srvals = gv.srvals
+        disableShiftRegisterOutput()
+        setShiftRegister(gv.output_srvals)  # gv.srvals stores shift register state
+        enableShiftRegisterOutput()
+        zone_change.send()

--- a/gv.py
+++ b/gv.py
@@ -5,9 +5,10 @@
 ##############################
 #### Revision information ####
 import subprocess
+from threading import RLock
 
 major_ver = 3
-minor_ver = 0
+minor_ver = 1
 old_count = 275
 
 try:
@@ -93,15 +94,18 @@ except IOError:  # If file does not exist, it will be created using defaults.
         json.dump(sd, sdf)
 
 
-now = timegm(time.localtime())
+nowt = time.localtime()
+now = timegm(nowt)
 tz_offset = int(time.time() - timegm(time.localtime())) # compatible with Javascript (negative tz shown as positive value)
 plugin_menu = []  # Empty list of lists for plugin links (e.g. ['name', 'URL'])
 
 srvals = [0] * (sd['nst'])  # Shift Register values
+output_srvals = [0] * (sd['nst'])  # Shift Register values last set by set_output()
+output_srvals_lock = RLock()
 rovals = [0] * sd['nbrd'] * 7  # Run Once durations
 snames = station_names()  # Load station names from file
 pd = load_programs()  # Load program data from file
-
+plugin_data = {}  # Empty dictionary to hold plugin based global data
 ps = []  # Program schedule (used for UI display)
 for i in range(sd['nst']):
     ps.append([0, 0])

--- a/gv_reference.txt
+++ b/gv_reference.txt
@@ -48,8 +48,11 @@ theme: "original" files used to style the UItyle the UI
 other gv attributes:
 gv.ver	software rev number (int, converted to dot separated digets in UI)
 gv.ver_date	date of release (string)
+gv.nowt	current time as struct time, updated once per second at top of timing loop
 gv.now	current time, updated once per second at top of timing loop
 gv.srvals	shift register values, used to turn zones on or off (list of one byte per station, 1 = turn on, 0 = turn off)
+gv.output_srvals	shift register values, used to turn zones on or off (list of one byte per station, 1 = turn on, 0 = turn off)
+gv.outpu_srvals_lock  a mutex used whenever gv.output_srvals must be accessed atomically
 gv.rovals	run once values - list of duration times in seconds for a run once program (list, length = number of statons)
 gv.pd	program data - loaded from file at startup (list of lists)
 gv.ps	program schedule used for UI display (list of 2 element lists i.e. [program number, duration])
@@ -59,3 +62,4 @@ gv.rs	run schedule (list [scheduled start time, scheduled stop time, duration, p
 gv.lrun	last run, used to display log line on home page (list [station index, program number, duration, end time]) 
 gv.scount	station count, used in set station to track on stations with master association
 gv.plugin_menu list to hold a 2 element list for each plugin to be added to menu on home page (['menu text', 'url'])
+gv.plugin_data dictionary (index by plugin root web prefix) to hold plugin data.

--- a/sip.py
+++ b/sip.py
@@ -29,7 +29,8 @@ def timing_loop():
         pass
     last_min = 0
     while True:  # infinite loop
-        gv.now = timegm(time.localtime())   # Current time as timestamp based on local time from the Pi. updated once per second.
+        gv.nowt = time.localtime()   # Current time as time struct.  Updated once per second.
+        gv.now = timegm(gv.nowt)   # Current time as timestamp based on local time from the Pi. Updated once per second.
         if gv.sd['en'] and not gv.sd['mm'] and (not gv.sd['bsy'] or not gv.sd['seq']):
             if gv.now / 60 != last_min:  # only check programs once a minute
                 last_min = gv.now / 60
@@ -198,6 +199,19 @@ if __name__ == '__main__':
         print ' ', name
 
     gv.plugin_menu.sort(key=lambda entry: entry[0])
+
+    # Ensure first three characters ('/' plus two characters of base name of each
+    # plugin is unique.  This allows the gv.plugin_data dictionary to be indexed
+    # by the two characters in the base name.
+    plugin_map = {}
+    for p in gv.plugin_menu:
+        three_char = p[1][0:3]
+        if three_char not in plugin_map:
+            plugin_map[three_char] = p[0] + '; ' + p[1]
+        else:
+            print 'ERROR - Plugin Conflict:', p[0] + '; ' + p[1] + ' and ', plugin_map[three_char]
+            exit()
+
     #  Keep plugin manager at top of menu
     try:
         gv.plugin_menu.pop(gv.plugin_menu.index(['Manage Plugins', '/plugins']))


### PR DESCRIPTION
…e key is the first two characters of the plugins base url (not including '/'.  Also create gv.output_srvals which is the state of the output pins and can be atomically accessed by multiple threads to ensure consistent views of the data.

Dont quite know why the merge cant be automatic  (Maybe zone_change.send() in sip.py apparent conflict.

I think having the gv.plugin_data will reduce the amount of plugin specific stuff that has to get put in gv.