### PR TITLE
Enable the use of either pigpio or GPIO as pin control

### DIFF
--- a/gpio_pins.py
+++ b/gpio_pins.py
@@ -3,42 +3,70 @@
 import gv
 
 try:
-    import RPi.GPIO as GPIO  # Required for accessing General Purpose Input Output pins on Raspberry Pi
+    import RPi.GPIO as GPIO
     gv.platform = 'pi'
+    rev = GPIO.RPI_REVISION
+    if rev == 1:
+        # map 26 physical pins (1based) with 0 for pins that do not have a gpio number
+        if gv.use_pigpio:
+            gv.pin_map = [0,0,0,0,0,1,0,4,14,0,15,17,18,21,0,22,23,0,24,10,0,9,25,11,8,0,7]
+        else:
+            gv.pin_map = [0,0,0,0,0,5,0,7,8,0,10,11,12,13,0,15,16,0,18,19,0,21,22,23,24,0,26]
+    elif rev == 2:
+        # map 26 physical pins (1based) with 0 for pins that do not have a gpio number
+        if gv.use_pigpio:
+            gv.pin_map = [0,0,0,2,0,3,0,4,14,0,15,17,18,27,0,22,23,0,24,10,0,9,25,11,8,0,7]
+        else:
+            gv.pin_map = [0,0,0,0,0,5,0,7,8,0,10,11,12,13,0,15,16,0,18,19,0,21,22,23,24,0,26]
+    elif rev == 3:
+        # map 40 physical pins (1based) with 0 for pins that do not have a gpio number
+        if gv.use_pigpio:
+            gv.pin_map = [0,0,0,2,0,3,0,4,14,0,15,17,18,27,0,22,23,0,24,10,0,9,25,11,8,0,7,0,0,5,0,6,12,13,0,19,16,26,20,0,21]
+        else:
+            gv.pin_map = [0,0,0,3,0,5,0,7,8,0,10,11,12,13,0,15,16,0,18,19,0,21,22,23,24,0,26,0,0,29,0,31,32,33,0,35,36,37,38,0,40]
+    else:
+        print 'Unknown pi pin revision.  Using pin mapping for rev 3'
+
 except ImportError:
     try:
         import Adafruit_BBIO.GPIO as GPIO  # Required for accessing General Purpose Input Output pins on Beagle Bone Black
+        gv.pin_map = [''*11] # map only the pins we are using
+        gv.pin_map.extend(['P9_'+str(i) for i in range(11,17)])
         gv.platform = 'bo'
     except ImportError:
+        gv.pin_map = [i for i in range(27)] # assume 26 pins all mapped.  Maybe we should not assume anything, but...
         gv.platform = ''  # if no platform, allows program to still run.
         print 'No GPIO module was loaded from GPIO Pins module'
 
 from blinker import signal
-
 zone_change = signal('zone_change')
 
 try:
-    GPIO.setwarnings(False)
+    if gv.use_pigpio:
+        import pigpio
+        pi = pigpio.pi()
+    else:
+        GPIO.setwarnings(False)
+        GPIO.setmode(GPIO.BOARD) #IO channels are identified by header connector pin numbers. Pin numbers are 
 except Exception:
     pass
 
 
 global pin_rain_sense
-global pin_relay
 
 try:
     if gv.platform == 'pi':  # If this will run on Raspberry Pi:
-        GPIO.setmode(GPIO.BOARD)  # IO channels are identified by header connector pin numbers. Pin numbers are always the same regardless of Raspberry Pi board revision.
-        pin_rain_sense = 8
-        pin_relay = 10               
+        pin_rain_sense = gv.pin_map[8]
     elif gv.platform == 'bo':  # If this will run on Beagle Bone Black:
-        pin_rain_sense = "P9_15"
-        pin_relay = "P9_16"        
+        pin_rain_sense = gv.pin_map[15]
 except AttributeError:
     pass
+
 try:
-    GPIO.setup(pin_rain_sense, GPIO.IN)
-    GPIO.setup(pin_relay, GPIO.OUT)    
+    if gv.use_pigpio:
+        pi.set_mode(pin_rain_sense, pigpio.INPUT)
+    else:
+        GPIO.setup(pin_rain_sense, GPIO.IN)
 except NameError:
     pass
 
@@ -55,29 +83,40 @@ def setup_pins():
 
     try:
         if gv.platform == 'pi':  # If this will run on Raspberry Pi:
-            GPIO.setmode(GPIO.BOARD)  # IO channels are identified by header connector pin numbers. Pin numbers are always the same regardless of Raspberry Pi board revision.
-            pin_sr_dat = 13
-            pin_sr_clk = 7
-            pin_sr_noe = 11
-            pin_sr_lat = 15
+            if not gv.use_pigpio:
+                GPIO.setmode(GPIO.BOARD)  # IO channels are identified by header connector pin numbers. Pin numbers are always the same regardless of Raspberry Pi board revision.
+            pin_sr_dat = gv.pin_map[13]
+            pin_sr_clk = gv.pin_map[7]
+            pin_sr_noe = gv.pin_map[11]
+            pin_sr_lat = gv.pin_map[15]
         elif gv.platform == 'bo':  # If this will run on Beagle Bone Black:
-            pin_sr_dat = "P9_11"
-            pin_sr_clk = "P9_13"
-            pin_sr_noe = "P9_14"
-            pin_sr_lat = "P9_12"
+            pin_sr_dat = gv.pin_map[11]
+            pin_sr_clk = gv.pin_map[13]
+            pin_sr_noe = gv.pin_map[14]
+            pin_sr_lat = gv.pin_map[12]
     except AttributeError:
         pass
 
     #### setup GPIO pins as output or input ####
     try:
-        GPIO.setup(pin_sr_noe, GPIO.OUT)
-        GPIO.output(pin_sr_noe, GPIO.HIGH)
-        GPIO.setup(pin_sr_clk, GPIO.OUT)
-        GPIO.output(pin_sr_clk, GPIO.LOW)
-        GPIO.setup(pin_sr_dat, GPIO.OUT)
-        GPIO.output(pin_sr_dat, GPIO.LOW)
-        GPIO.setup(pin_sr_lat, GPIO.OUT)
-        GPIO.output(pin_sr_lat, GPIO.LOW)
+        if gv.use_pigpio:
+            pi.set_mode(pin_sr_noe, pigpio.OUTPUT)
+            pi.set_mode(pin_sr_clk, pigpio.OUTPUT)
+            pi.set_mode(pin_sr_dat, pigpio.OUTPUT)
+            pi.set_mode(pin_sr_lat, pigpio.OUTPUT)
+            pi.write(pin_sr_noe, 1)
+            pi.write(pin_sr_clk, 0)
+            pi.write(pin_sr_dat, 0)
+            pi.write(pin_sr_lat, 0)
+        else:
+            GPIO.setup(pin_sr_noe, GPIO.OUT)
+            GPIO.setup(pin_sr_clk, GPIO.OUT)
+            GPIO.setup(pin_sr_dat, GPIO.OUT)
+            GPIO.setup(pin_sr_lat, GPIO.OUT)
+            GPIO.output(pin_sr_noe, GPIO.HIGH)
+            GPIO.output(pin_sr_clk, GPIO.LOW)
+            GPIO.output(pin_sr_dat, GPIO.LOW)
+            GPIO.output(pin_sr_lat, GPIO.LOW)
     except NameError:
         pass
 
@@ -91,7 +130,10 @@ def disableShiftRegisterOutput():
         if gv.use_gpio_pins:
             setup_pins()
     try:
-        GPIO.output(pin_sr_noe, GPIO.HIGH)
+        if gv.use_pigpio:
+            pi.write(pin_sr_noe, 1)
+        else:
+            GPIO.output(pin_sr_noe, GPIO.HIGH)
     except Exception:
         pass
 
@@ -100,7 +142,10 @@ def enableShiftRegisterOutput():
     """Enable output from shift register."""
 
     try:
-        GPIO.output(pin_sr_noe, GPIO.LOW)
+        if gv.use_pigpio:
+            pi.write(pin_sr_noe, 0)
+        else:
+            GPIO.output(pin_sr_noe, GPIO.LOW)
     except Exception:
         pass
 
@@ -109,16 +154,28 @@ def setShiftRegister(srvals):
     """Set the state of each output pin on the shift register from the srvals list."""
 
     try:
-        GPIO.output(pin_sr_clk, GPIO.LOW)
-        GPIO.output(pin_sr_lat, GPIO.LOW)
-        for s in range(gv.sd['nst']):
+        if gv.use_pigpio:
+            pi.write(pin_sr_clk, 0)
+            pi.write(pin_sr_lat, 0)
+            for s in range(gv.sd['nst']):
+                pi.write(pin_sr_clk, 0)
+                if srvals[gv.sd['nst']-1-s]:
+                    pi.write(pin_sr_dat, 1)
+                else:
+                    pi.write(pin_sr_dat, 0)
+                pi.write(pin_sr_clk, 1)
+            pi.write(pin_sr_lat, 1)
+        else:
             GPIO.output(pin_sr_clk, GPIO.LOW)
-            if srvals[gv.sd['nst']-1-s]:
-                GPIO.output(pin_sr_dat, GPIO.HIGH)
-            else:
-                GPIO.output(pin_sr_dat, GPIO.LOW)
-            GPIO.output(pin_sr_clk, GPIO.HIGH)
-        GPIO.output(pin_sr_lat, GPIO.HIGH)
+            GPIO.output(pin_sr_lat, GPIO.LOW)
+            for s in range(gv.sd['nst']):
+                GPIO.output(pin_sr_clk, GPIO.LOW)
+                if srvals[gv.sd['nst']-1-s]:
+                    GPIO.output(pin_sr_dat, GPIO.HIGH)
+                else:
+                    GPIO.output(pin_sr_dat, GPIO.LOW)
+                GPIO.output(pin_sr_clk, GPIO.HIGH)
+            GPIO.output(pin_sr_lat, GPIO.HIGH)
     except Exception:
         pass
 

--- a/gpio_pins.py
+++ b/gpio_pins.py
@@ -79,7 +79,7 @@ def setup_pins():
     global pin_sr_clk
     global pin_sr_noe
     global pin_sr_lat
-
+    global pi
 
     try:
         if gv.platform == 'pi':  # If this will run on Raspberry Pi:
@@ -124,6 +124,7 @@ def setup_pins():
 def disableShiftRegisterOutput():
     """Disable output from shift register."""
 
+    global pi
     try:
         pin_sr_noe
     except NameError:
@@ -141,6 +142,7 @@ def disableShiftRegisterOutput():
 def enableShiftRegisterOutput():
     """Enable output from shift register."""
 
+    global pi
     try:
         if gv.use_pigpio:
             pi.write(pin_sr_noe, 0)
@@ -153,6 +155,7 @@ def enableShiftRegisterOutput():
 def setShiftRegister(srvals):
     """Set the state of each output pin on the shift register from the srvals list."""
 
+    global pi
     try:
         if gv.use_pigpio:
             pi.write(pin_sr_clk, 0)

--- a/gv.py
+++ b/gv.py
@@ -37,6 +37,12 @@ import time
 
 platform = ''  # must be done before the following import because gpio_pins will try to set it
 
+try:
+    import pigpio
+    use_pigpio = True
+except ImportError:
+    use_pigpio = False
+
 from helpers import password_salt, password_hash, load_programs, station_names
 
 sd = {

--- a/gv_reference.txt
+++ b/gv_reference.txt
@@ -63,3 +63,4 @@ gv.lrun	last run, used to display log line on home page (list [station index, pr
 gv.scount	station count, used in set station to track on stations with master association
 gv.plugin_menu list to hold a 2 element list for each plugin to be added to menu on home page (['menu text', 'url'])
 gv.plugin_data dictionary (index by plugin root web prefix) to hold plugin data.
+gv.use_pigpio  set if pigpio libary is installed.

--- a/helpers.py
+++ b/helpers.py
@@ -183,6 +183,7 @@ def mkdir_p(path):
             raise
 
 def check_rain():
+    global pi
     try:
         if gv.sd['rst'] == 1:  # Rain sensor type normally open (default)
             if gv.use_pigpio:

--- a/sip.py
+++ b/sip.py
@@ -12,9 +12,9 @@ import sys
 sys.path.append('./plugins')
 
 import web  # the Web.py module. See webpy.org (Enables the Python SIP web interface)
-import gv
 
-from helpers import plugin_adjustment, prog_match, schedule_stations, log_run, stop_onrain, check_rain, jsave, station_names
+import gv
+from helpers import plugin_adjustment, prog_match, schedule_stations, log_run, stop_onrain, check_rain, jsave, station_names, get_rpi_revision
 from urls import urls  # Provides access to URLs for UI pages
 from gpio_pins import set_output
 # do not call set output until plugins are loaded because it should NOT be called


### PR DESCRIPTION
I believe this checkin works with pigpio installed on a system.

I also tried it without using the pigpio library and it seems ok, but it would be great if you have a system without pigpio installed and see if it works for you.

There is also a change in relay_board.py in the plugins directory.  I will try to commit that too and issue a pull request to your sip_plugins.
