### PR TITLE
update sip.py to remove extra space on first line

### DIFF
--- a/sip.py
+++ b/sip.py
@@ -1,4 +1,4 @@
-# !/usr/bin/env python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 import i18n


### PR DESCRIPTION
Remove extra space after the shebang and the command.   With this space the shell is unable to figure out the proper interpreter for the file-- user would get shell error "include not found"--when just typing "./sip.py" from the shell.  Does not impact the usual way of starting the script with "python sip.py" so should be harmless.  
Found this when without thinking tried to start the command without specifying an interpreter like the standard startup script does.