### PR TITLE
Make recurring detection based on integer minute boundary

### DIFF
--- a/templates/modify.html
+++ b/templates/modify.html
@@ -48,7 +48,7 @@ $code:
 				stationsOn = stationsOn + 1
 	even = program[1]&0x80 and program[2]==0
 	odd = program[1]&0x80 and program[2]==1
-	recurring = program[3] + program[6]/60*stationsOn < program[4]
+	recurring = int(program[3] + program[6]/60*stationsOn) < int(program[4])
 	tf = gv.sd['tf']
 	def formatTime(t):
 		if gv.sd['tf']:

--- a/templates/programs.html
+++ b/templates/programs.html
@@ -141,7 +141,7 @@ $code:
             <p>$_('Starting'): <span class="val">${formatTime(two_digits(start/60) + ":" + two_digits(start%60))}</span>
                 <span ${"" if not (gv.sd['idd'] > 0) else "style=display:none"}>$_('for') <span class="val">${(duration/60>>0)}</span> mins<span class="val">${"" if (duration%60) == 0 else (" " + str(duration%60) + " secs")}</span></span>
                 <span ${"" if (gv.sd['idd'] > 0) else "style=display:none"}>$_('with individual station durations')</span></p>
-            $ recurring = start + duration/60*stationsOn < end
+            $ recurring = int(start + duration/60*stationsOn) < int(end)
             $if recurring:
                 <p>$_('Recurring every')</b> <span class="val">${two_digits(interval/60)}</span> hrs <span class="val">${two_digits(interval%60)}</span> mins
                 $_('until') <span class="val">${formatTime(two_digits(end/60) + ":" + two_digits(end%60))}</span></p>


### PR DESCRIPTION
This correct a behavior observed when station duration and program duration have fractional minutes (ex: 10:05).  After a program edit and save, the "recurring" status is turned on in the program list and program edit Web pages.
 