### PR TITLE
Display duration and end time for non-recurrent program with idd

### DIFF
--- a/templates/programs.html
+++ b/templates/programs.html
@@ -144,6 +144,9 @@ $code:
             $ recurring = int(start + duration/60*stationsOn) < int(end)
             $if recurring:
                 <p>$_('Recurring every')</b> <span class="val">${two_digits(interval/60)}</span> hrs <span class="val">${two_digits(interval%60)}</span> mins
+				$_('until') <span class="val">${formatTime(two_digits(end/60) + ":" + two_digits(end%60))}</span></p>
+            $if not recurring and gv.sd['idd'] > 0:
+                <p>$_('for')</b> <span class="val">${two_digits(interval/60)}</span> hrs <span class="val">${two_digits(interval%60)}</span> mins <span class="val">${two_digits((interval%1)*60)}</span> secs 
                 $_('until') <span class="val">${formatTime(two_digits(end/60) + ":" + two_digits(end%60))}</span></p>
 
             <p>


### PR DESCRIPTION
Improve program list summary by the displaying total duration and end time when non-recurrent and individual station duration.