### PR TITLE
Correct individual station duration side effects

### DIFF
--- a/templates/modify.html
+++ b/templates/modify.html
@@ -37,23 +37,33 @@ $code:
 
 	weekly = not((program[1]&0x80) and (program[2]>1))
 	stationsShown = 0
-	duration = 0
-	sid = -1
 	for bid in range(gv.sd['nbrd']):
 		if not isinstance(program[bid+7], int):
 			program.insert(-1, 0)		
 		boardShow = gv.sd['show'][bid]
 		for s in range(8):
-			sid += 1
 			stationsShown += (boardShow>>s) & 1
-			if program[bid+7]&(1<<s):
-				if gv.sd['idd'] :
-					duration += program[-1][sid]
+
+	duration = 0
+	sid = -1
+	for b in range(gv.sd['nbrd']):
+		for s in range(8):
+			sid += 1
+			if program[b+7]&(1<<s):
+				if gv.sd['seq'] :
+					if gv.sd['idd'] :
+						duration += program[-1][sid]
+					else:
+						duration += program[6]
 				else:
-					duration += program[6]
+					if gv.sd['idd'] :
+						duration = max(duration, program[-1][sid])
+					else:
+						duration = program[6]
+	lap_end = program[3] + duration/60
+	recurring = int(lap_end) < int(program[4])
 	even = program[1]&0x80 and program[2]==0
 	odd = program[1]&0x80 and program[2]==1
-	recurring = int(program[3] + duration/60) < int(program[4])
 	tf = gv.sd['tf']
 	def formatTime(t):
 		if gv.sd['tf']:
@@ -266,26 +276,44 @@ $code:
                 }
             }
 
+            // process general duration
+            var dm = parseInt(jQuery("#tdm").val());
+            var ds = parseInt(jQuery("#tds").val());
+            var gduration = dm*60 + ds;
+            if (!(dm>=0 && ds>=0 && ds<60 && gduration>0)) {
+                alert($:{json.dumps(_('Error: Duration missing.'), ensure_ascii=False)});
+                return;
+            }
+
             // Process individual station times
             var t = "[";
-            var total_t=0;
+            var lap_t=0;
+			var sduration = 0;
 			for (var bid=0; bid<nbrd; bid++) {
                 for (var s=0; s<8; s++) {
                     sid = bid*8 + s;
                     var stationOn = jQuery("button#station"+sid).hasClass("on")
-                    if (idd && stationOn) {
-                        var dm = parseInt(jQuery("#tdm" + sid).val());
-                        var ds = parseInt(jQuery("#tds" + sid).val());
-                        var duration = dm*60 + ds;
-                        if (!(dm>=0 && ds>=0 && ds<60 && duration>0)) {
-                            alert($:{json.dumps(_('Error: Incorrect duration.'), ensure_ascii=False)});
-                            return;
-                        }
+					if (stationOn) {
+						if (idd) {
+							var dm = parseInt(jQuery("#tdm" + sid).val());
+							var ds = parseInt(jQuery("#tds" + sid).val());
+							sduration = dm*60 + ds;
+							if (!(dm>=0 && ds>=0 && ds<60 && sduration>0)) {
+								alert($:{json.dumps(_('Error: Incorrect duration.'), ensure_ascii=False)});
+								return;
+							}
+						} else {
+							   sduration = gduration;
+						}
+					} else {
+						sduration = 0;
+					}
+                    t += sduration;
+                    if (seq) {
+					    lap_t += sduration;
                     } else {
-                        duration = 0;
+					    lap_t = Math.max(lap_t, sduration);
                     }
-                    t += duration;
-					total_t += duration;
                     if(s < 7)
                         t += ",";
                 }
@@ -294,27 +322,14 @@ $code:
             }
             t += "]";
 
-            // process general duration
-            var dm = parseInt(jQuery("#tdm").val());
-            var ds = parseInt(jQuery("#tds").val());
-            var duration = dm*60 + ds;
-            if (!(dm>=0 && ds>=0 && ds<60 && duration>0)) {
-                alert($:{json.dumps(_('Error: Duration missing.'), ensure_ascii=False)});
-                return;
-            }
-
             // process time
             var startTime = parseTime("ts");
             if (jQuery("button#cRecurring").hasClass("on")) {
-				if (idd) {
-						var interval = total_t/60;;
-                    } else {
-						var interval = jQuery(".station.on").length * duration/60;
-				}
+				var interval = lap_t/60;
                 var endTime = startTime + interval;
             } else {
-                var endTime = parseTime("te");
                 var interval = parseTime("ti");
+                var endTime = parseTime("te");
             }
             if (startTime >= endTime) {
                 // Possible bug - can you run a program from 10PM to 2AM?
@@ -322,7 +337,7 @@ $code:
                 return;
             }
 
-            var v = "[" + en + "," + days + "," + dayInterval + "," + startTime + "," + endTime + "," + interval + "," + duration;
+            var v = "[" + en + "," + days + "," + dayInterval + "," + startTime + "," + endTime + "," + interval + "," + gduration;
             for (var i=0; i<nbrd; i++) {
                 v += "," + stations[i];
             }

--- a/templates/modify.html
+++ b/templates/modify.html
@@ -37,18 +37,23 @@ $code:
 
 	weekly = not((program[1]&0x80) and (program[2]>1))
 	stationsShown = 0
-	stationsOn = 0
-	for bid in range(0, gv.sd['nbrd']):
+	duration = 0
+	sid = -1
+	for bid in range(gv.sd['nbrd']):
 		if not isinstance(program[bid+7], int):
 			program.insert(-1, 0)		
 		boardShow = gv.sd['show'][bid]
-		for s in range(0,8):
+		for s in range(8):
+			sid += 1
 			stationsShown += (boardShow>>s) & 1
 			if program[bid+7]&(1<<s):
-				stationsOn = stationsOn + 1
+				if gv.sd['idd'] :
+					duration += program[-1][sid]
+				else:
+					duration += program[6]
 	even = program[1]&0x80 and program[2]==0
 	odd = program[1]&0x80 and program[2]==1
-	recurring = int(program[3] + program[6]/60*stationsOn) < int(program[4])
+	recurring = int(program[3] + duration/60) < int(program[4])
 	tf = gv.sd['tf']
 	def formatTime(t):
 		if gv.sd['tf']:

--- a/templates/programs.html
+++ b/templates/programs.html
@@ -136,10 +136,16 @@ $code:
                     $ sid += 1
                     $if (gv.sd['show'][bid]>>s)&1 and bits&(1<<s):
                         <span class="stationName val">${snames[sid]}</span>
-                        $if gv.sd['idd'] > 0 :
-                            $ duration += prog[-1][sid]
+                        $if gv.sd['seq'] :
+                            $if gv.sd['idd'] :
+                                $ duration += prog[-1][sid]
+                            $else:
+                                $ duration += prog[6]
                         $else:
-                            $ duration += prog[6]
+                            $if gv.sd['idd'] :
+                                $ duration = max(duration, prog[-1][sid])
+                            $else:
+                                $ duration = prog[6]
             $ lap_end = start + duration / 60
             $ recurring = int(lap_end) < int(end)
 							

--- a/templates/programs.html
+++ b/templates/programs.html
@@ -136,22 +136,21 @@ $code:
                     $ sid += 1
                     $if (gv.sd['show'][bid]>>s)&1 and bits&(1<<s):
                         <span class="stationName val">${snames[sid]}</span>
-                        $if gv.sd['idd']:
+                        $if gv.sd['idd'] > 0 :
                             $ duration += prog[-1][sid]
                         $else:
                             $ duration += prog[6]
+            $ lap_end = start + duration / 60
+            $ recurring = int(lap_end) < int(end)
 							
             </p>
             <p>$_('Starting'): <span class="val">${formatTime(two_digits(start/60) + ":" + two_digits(start%60))}</span>
-                <span ${"" if not (gv.sd['idd'] > 0) else "style=display:none"}>$_('for') <span class="val">${(duration/60>>0)}</span> mins<span class="val">${"" if (duration%60) == 0 else (" " + str(duration%60) + " secs")}</span></span>
                 <span ${"" if (gv.sd['idd'] > 0) else "style=display:none"}>$_('with individual station durations')</span></p>
-            $ recurring = int(start + duration/60) < int(end)
+                <p>$_('for')</b> <span class="val">${two_digits(duration/3600)}</span> hrs <span class="val">${two_digits(((duration/60)%60))}</span> mins <span class="val">${two_digits(duration%60)}</span> secs 
+                $_('until') <span class="val">${formatTime(two_digits(lap_end/60) + ":" + two_digits(lap_end%60))}</span></p>
             $if recurring:
                 <p>$_('Recurring every')</b> <span class="val">${two_digits(interval/60)}</span> hrs <span class="val">${two_digits(interval%60)}</span> mins
 				$_('until') <span class="val">${formatTime(two_digits(end/60) + ":" + two_digits(end%60))}</span></p>
-            $if not recurring and gv.sd['idd'] > 0:
-                <p>$_('for')</b> <span class="val">${two_digits(interval/60)}</span> hrs <span class="val">${two_digits(interval%60)}</span> mins <span class="val">${two_digits((interval%1)*60)}</span> secs 
-                $_('until') <span class="val">${formatTime(two_digits(end/60) + ":" + two_digits(end%60))}</span></p>
 
             <p>
                 <button class="cRunNow" data="${pid}">$_('Run Now')</button>

--- a/templates/programs.html
+++ b/templates/programs.html
@@ -124,24 +124,28 @@ $code:
             $ start = prog[3]
             $ end = prog[4]
             $ interval = prog[5]
-            $ duration = prog[6]
+            $ duration = 0
             <p class="stationList">$_('Run'):
-            $ stationsOn = 0
-            $for bid in range(0,gv.sd['nbrd']):
+			$ sid = -1
+            $for bid in range(gv.sd['nbrd']):
                 $if len(prog) >= 8 + bid and isinstance(prog[7 + bid], int):
                     $ bits = prog[7 + bid]
                 $else:
                     $ bits = 0
-                $for s in range(0,8):
-                    $ sid = bid*8 + s
+                $for s in range(8):
+                    $ sid += 1
                     $if (gv.sd['show'][bid]>>s)&1 and bits&(1<<s):
                         <span class="stationName val">${snames[sid]}</span>
-                        $ stationsOn = stationsOn + 1
+                        $if gv.sd['idd']:
+                            $ duration += prog[-1][sid]
+                        $else:
+                            $ duration += prog[6]
+							
             </p>
             <p>$_('Starting'): <span class="val">${formatTime(two_digits(start/60) + ":" + two_digits(start%60))}</span>
                 <span ${"" if not (gv.sd['idd'] > 0) else "style=display:none"}>$_('for') <span class="val">${(duration/60>>0)}</span> mins<span class="val">${"" if (duration%60) == 0 else (" " + str(duration%60) + " secs")}</span></span>
                 <span ${"" if (gv.sd['idd'] > 0) else "style=display:none"}>$_('with individual station durations')</span></p>
-            $ recurring = int(start + duration/60*stationsOn) < int(end)
+            $ recurring = int(start + duration/60) < int(end)
             $if recurring:
                 <p>$_('Recurring every')</b> <span class="val">${two_digits(interval/60)}</span> hrs <span class="val">${two_digits(interval%60)}</span> mins
 				$_('until') <span class="val">${formatTime(two_digits(end/60) + ":" + two_digits(end%60))}</span></p>

--- a/webpages.py
+++ b/webpages.py
@@ -484,18 +484,23 @@ class run_now(ProtectedPage):
 #           Sraise web.seeother('/vp')
         stop_stations()
         extra_adjustment = plugin_adjustment()
-        for b in range(len(p[7:7 + gv.sd['nbrd']])):  # check each station
+        sid = -1
+        for b in range(gv.sd['nbrd']):  # check each station
             for s in range(8):
-                sid = b * 8 + s  # station index
+                sid += 1  # station index
                 if sid + 1 == gv.sd['mas']:  # skip if this is master valve
                     continue
                 if p[7 + b] & 1 << s:  # if this station is scheduled in this program
-                    gv.rs[sid][2] = p[6]
+                    if gv.sd['idd']:
+                        duration = p[-1][sid]
+                    else:
+                        duration = p[6]
                     if not gv.sd['iw'][b] & 1 << s:
-                        gv.rs[sid][2] = gv.rs[sid][2] * gv.sd['wl'] / 100 * extra_adjustment
+                        duration = duration * gv.sd['wl'] / 100 * extra_adjustment
+                    gv.rs[sid][2] = duration
                     gv.rs[sid][3] = pid + 1  # store program number in schedule
                     gv.ps[sid][0] = pid + 1  # store program number for display
-                    gv.ps[sid][1] = gv.rs[sid][2]  # duration
+                    gv.ps[sid][1] = duration  # duration
         schedule_stations(p[7:7 + gv.sd['nbrd']])
         raise web.seeother('/')
 


### PR DESCRIPTION
For individual station duration, and in complement to #186 and #184 this:
- correct the calculation of the "recurrent" status in programs.html and modify.html,
- properly schedule the program "run now" (webpages.py),
- improve the starting and recurring status programs display.
