### PR TITLE
fix restart without GPIO module

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -93,7 +93,10 @@ def reboot(wait=1, block=False):
         if gv.use_pigpio:
             pass
         else:
-            GPIO.cleanup()
+            try:
+                GPIO.cleanup()
+            except NameError:
+                pass
         time.sleep(wait)
         try:
             print _('Rebooting...')
@@ -122,7 +125,10 @@ def poweroff(wait=1, block=False):
         if gv.use_pigpio:
             pass
         else:
-            GPIO.cleanup()
+            try:
+                GPIO.cleanup()
+            except NameError:
+                pass
         time.sleep(wait)
         try:
             print _('Powering off...')
@@ -152,7 +158,10 @@ def restart(wait=1, block=False):
         if gv.use_pigpio:
             pass
         else:
-            GPIO.cleanup()
+            try:
+                GPIO.cleanup()
+            except NameError:
+                pass
         time.sleep(wait)
         try:
             print _('Restarting...')


### PR DESCRIPTION
Restarting SIP from the UI causes Python exceptions if you don't have a GPIO module. Most cases handle exceptions on accessing the GPIO module but the restart methods don't.