### PR TITLE
fix logging to syslog by systemd

### DIFF
--- a/sip.service
+++ b/sip.service
@@ -4,8 +4,9 @@
 Description=SIP
 After=syslog.target network.target
 [Service]
-ExecStart=/usr/bin/python /home/pi/SIP/sip.py
+ExecStart=/usr/bin/python -u /home/pi/SIP/sip.py
 Restart=on-abort
 WorkingDirectory=/home/pi/SIP/
+SyslogIdentifier=sip
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This change makes systemd's logging of sip's output to syslog work better.

* Use python -u to force stdout to be unbuffered, else the output doesn't appear until the buffer gets full
* Add a syslog identifier
