### PR TITLE
Interval program schedule correction

### DIFF
--- a/static/scripts/schedule.js
+++ b/static/scripts/schedule.js
@@ -8,11 +8,11 @@ if (typeof nbrd !== 'undefined'){var nst = nbrd*8}; // number of stations
 function scheduledThisDate(pd,simminutes,simdate) { // check if progrm is scheduled for this date (displayScheduleDate) called from doSimulation
   // simminutes is minute count generated in doSimulation()
   // simdate is a JavaScript date object
-  simday = Math.floor(simdate/(1000*3600*24)) // The number of days since epoc
   var wd,dn;
   if(pd['enabled']==0)  return 0; // program not enabled, do not match
   if(pd['type'] == 'interval') { // if interval program... 
-    if(((simday)%pd['interval_base_day'])!=pd['day_mask']) return 0; // remainder checking	
+	simday = Math.floor(new Date(simdate.getUTCFullYear(), simdate.getUTCMonth(), simdate.getUTCDate(),Math.floor(simminutes/60), simminutes%60)/(1000*60*60*24))
+	if(((simday)%pd['interval_base_day'])!=pd['day_mask']) return 0; // remainder checking	
   } else { // Not interval 
     wd=(simdate.getDay()+6)%7; // getDay assumes sunday is 0, converts to Monday is 0 (weekday index)
     if((pd['day_mask']&(1<<wd))==0) return 0; // weekday checking  
@@ -267,7 +267,7 @@ function displayProgram() { // Controls home page irrigation timeline
 					}
 				}
 				log[l].label = toClock(recorded_log_start, timeFormat) + " for " + toClock(log[l].duration/60, 1);
-				if (log[l].adjustment != undefined && log[l].adjustment != 0) {
+				if (log[l].adjustment != undefined && log[l].adjustment != "100") {
 					log[l].label += " (adjusted " + log[l].adjustment + "%)";
 				}
 			}

--- a/static/themes/basic/base.css
+++ b/static/themes/basic/base.css
@@ -567,11 +567,11 @@ td.stationSchedule {
 	background-color: #397F19;	
 }
 .scheduleMarker .markerDetail {
+	overflow-x:hidden;
+	overflow-y:hidden;
 	display:none;
 }
 .scheduleTick {
-	overflow-x:hidden;
-	overflow-y:hidden;
 	position: relative;
 	font-size: 9px;
 	text-align:center;


### PR DESCRIPTION
The projected interval programs would not match what actually will run, depending on when the projection was viewed.  Intervals are calculated at the time the program is started.  The schedule was calculating based on the time the schedule was viewed.  Thus there could is a window of possible display error, for anybody viewing the schedule in other time zones.  Now the schedule evaluates the interval based on the program start date/time, not on the schedule viewing time. 