### PR TITLE
Align program list and program edit interface with interval behavior

### DIFF
--- a/gv.py
+++ b/gv.py
@@ -103,13 +103,12 @@ if sd["pigpio"]:
 else:
     use_pigpio = False
 
-from helpers import load_programs, station_names, days_since_epoch
+from helpers import load_programs, station_names
 
 day_ord = 0
 node_runs = {}
 now = time.time()
 nowt = time.localtime(now)
-dse = days_since_epoch()
 
 tz_offset = round(now - timegm(nowt)
 )  # compatible with Javascript (negative tz shown as positive value)

--- a/gv.py
+++ b/gv.py
@@ -103,12 +103,13 @@ if sd["pigpio"]:
 else:
     use_pigpio = False
 
-from helpers import load_programs, station_names
+from helpers import load_programs, station_names, days_since_epoch
 
 day_ord = 0
 node_runs = {}
 now = time.time()
 nowt = time.localtime(now)
+dse = days_since_epoch()
 
 tz_offset = round(now - timegm(nowt)
 )  # compatible with Javascript (negative tz shown as positive value)

--- a/gv_reference.txt
+++ b/gv_reference.txt
@@ -92,6 +92,7 @@ gv.cputemp              CPU temperature from internal sensor.
 gv.day_ord              Day of year as int (ordinal)
 gv.now                  current time as timestamp, updated once per second at top of timing loop
 gv.nowt                 current time as struct time, updated once per second at top of timing loop
+gv.dse                  days since epoch, providing a "daystamp" against which to evaluate interval programs, updated with gv.now
 gv.output_srvals [S]    shift register values, used to turn zones on or off (list of one byte per station, 1 = turn on, 0 = turn off)
 gv.output_srvals_lock   a mutex used whenever gv.output_srvals must be accessed atomically
 gv.plugin_data          dictionary (index by plugin root web prefix) to hold plugin data.

--- a/gv_reference.txt
+++ b/gv_reference.txt
@@ -92,7 +92,6 @@ gv.cputemp              CPU temperature from internal sensor.
 gv.day_ord              Day of year as int (ordinal)
 gv.now                  current time as timestamp, updated once per second at top of timing loop
 gv.nowt                 current time as struct time, updated once per second at top of timing loop
-gv.dse                  days since epoch, providing a "daystamp" against which to evaluate interval programs, updated with gv.now
 gv.output_srvals [S]    shift register values, used to turn zones on or off (list of one byte per station, 1 = turn on, 0 = turn off)
 gv.output_srvals_lock   a mutex used whenever gv.output_srvals must be accessed atomically
 gv.plugin_data          dictionary (index by plugin root web prefix) to hold plugin data.

--- a/templates/modify.html
+++ b/templates/modify.html
@@ -68,9 +68,10 @@ $code:
                 newhour = hour-12
             return str(newhour)  + t[2:] + (" am" if hour<12 else " pm")
             
-    def pdays(days, dayInterval):
-        days = days & 0x7f
-        daysRemaining = ((days + dayInterval)-(gv.dse % dayInterval)) % dayInterval
+    def pdays(daym, dayInterval):
+        daym = daym & 0x7f
+        dse = int(gv.now/86400) # days since epoc
+        daysRemaining = ((daym + dayInterval)-(dse % dayInterval)) % dayInterval
         return daysRemaining
 
 <script>

--- a/templates/modify.html
+++ b/templates/modify.html
@@ -68,10 +68,9 @@ $code:
                 newhour = hour-12
             return str(newhour)  + t[2:] + (" am" if hour<12 else " pm")
             
-    def pdays(daym, dayInterval):
-        daym = daym & 0x7f
-        dse = int(gv.now/86400) # days since epoc
-        daysRemaining = ((daym + dayInterval)-(dse % dayInterval)) % dayInterval
+    def pdays(days, dayInterval):
+        days = days & 0x7f
+        daysRemaining = ((days + dayInterval)-(gv.dse % dayInterval)) % dayInterval
         return daysRemaining
 
 <script>

--- a/templates/programs.html
+++ b/templates/programs.html
@@ -19,10 +19,13 @@ $code:
         output = ""
         if prog['type'] == 'interval':
             days = days&0x7f
-            dse = int(gv.now/86400) # days since epoc
-            daysRemaining = ((days + dayInterval)-(dse % dayInterval)) % dayInterval
+            daysRemaining = ((days + dayInterval)-(gv.dse % dayInterval)) % dayInterval
             output += _(u"Every ") + str(dayInterval) + " " + _(u"days")
-            if daysRemaining:
+            if daysRemaining == 0:
+                output += ", " + _(u'starting today') + "."
+            elif daysRemaining == 1:
+                output += ", " + _(u'starting tomorrow') + "."
+            else:
                 output += ", " + _(u'starting in') + " " + str(daysRemaining) + " " + _(u'days') + "."
         else: 
             if days == 127:

--- a/templates/programs.html
+++ b/templates/programs.html
@@ -19,13 +19,10 @@ $code:
         output = ""
         if prog['type'] == 'interval':
             days = days&0x7f
-            daysRemaining = ((days + dayInterval)-(gv.dse % dayInterval)) % dayInterval
+            dse = int(gv.now/86400) # days since epoc
+            daysRemaining = ((days + dayInterval)-(dse % dayInterval)) % dayInterval
             output += _(u"Every ") + str(dayInterval) + " " + _(u"days")
-            if daysRemaining == 0:
-                output += ", " + _(u'starting today') + "."
-            elif daysRemaining == 1:
-                output += ", " + _(u'starting tomorrow') + "."
-            else:
+            if daysRemaining:
                 output += ", " + _(u'starting in') + " " + str(daysRemaining) + " " + _(u'days') + "."
         else: 
             if days == 127:

--- a/webpages.py
+++ b/webpages.py
@@ -536,10 +536,11 @@ class modify_program(ProtectedPage):
         if pid != -1:
             mp = gv.pd[pid]  # Modified program
             if mp["type"] == "interval":
+                dse = int(gv.now // 86400)
                 # Convert absolute to relative days remaining for display
                 rel_rem = (
                     ((mp["day_mask"]) + mp["interval_base_day"])
-                    - (gv.dse % mp["interval_base_day"])
+                    - (dse % mp["interval_base_day"])
                 ) % mp["interval_base_day"]
             p_name = mp["name"]
             prog = str(mp).replace(" ", "") #  strip out spaces
@@ -563,7 +564,8 @@ class change_program(ProtectedPage):
                 if gv.rs[i][3] == pnum:
                     gv.rs[i] = [0, 0, 0, 0]
         if cp["type"] == "interval":
-            ref = gv.dse + cp["day_mask"]  # - 128
+            dse = int(gv.now // 86400)
+            ref = dse + cp["day_mask"]  # - 128
             cp["day_mask"] = ref % cp["interval_base_day"]  # + 128
         if qdict["pid"] == "-1":  # add new program
             gv.pd.append(cp)

--- a/webpages.py
+++ b/webpages.py
@@ -536,11 +536,10 @@ class modify_program(ProtectedPage):
         if pid != -1:
             mp = gv.pd[pid]  # Modified program
             if mp["type"] == "interval":
-                dse = int(gv.now // 86400)
                 # Convert absolute to relative days remaining for display
                 rel_rem = (
                     ((mp["day_mask"]) + mp["interval_base_day"])
-                    - (dse % mp["interval_base_day"])
+                    - (gv.dse % mp["interval_base_day"])
                 ) % mp["interval_base_day"]
             p_name = mp["name"]
             prog = str(mp).replace(" ", "") #  strip out spaces
@@ -564,8 +563,7 @@ class change_program(ProtectedPage):
                 if gv.rs[i][3] == pnum:
                     gv.rs[i] = [0, 0, 0, 0]
         if cp["type"] == "interval":
-            dse = int(gv.now // 86400)
-            ref = dse + cp["day_mask"]  # - 128
+            ref = gv.dse + cp["day_mask"]  # - 128
             cp["day_mask"] = ref % cp["interval_base_day"]  # + 128
         if qdict["pid"] == "-1":  # add new program
             gv.pd.append(cp)


### PR DESCRIPTION
Use the canonical days_since_epoch() calculation everywhere, so that the program display doesn't differ from the schedule view (or device behavior) when viewed at certain times of day.