### PR TITLE
feat: use python virtual env for SIP

### DIFF
--- a/sip_service.sh
+++ b/sip_service.sh
@@ -4,6 +4,7 @@
 ###
 
 install_location=$(pwd)
+python3 -m venv --system-site-packages ${install_location}/.venv
 
 echo ===== Creating and installing SystemD service =====
 cat << EOF > /tmp/sip.service
@@ -15,7 +16,8 @@ After=syslog.target network.target network-online.target
 Wants=network-online.target
 
 [Service]
-ExecStart=/usr/bin/python3 -u ${install_location}/sip.py
+Environment="PATH=/${install_location}/.venv/bin:${PATH}"
+ExecStart=/${install_location}/.venv/bin/python3 -u ${install_location}/sip.py
 Restart=on-abort
 WorkingDirectory=${install_location}
 SyslogIdentifier=sip


### PR DESCRIPTION
When creating the sip-service, create a python virtual env to run SIP in.
This will allow plugins to install there own python libraries with cli pip3.