### PR TITLE
 fixed options: sdt, mton, wl

### DIFF
--- a/plugins/mobile_app.py
+++ b/plugins/mobile_app.py
@@ -47,7 +47,7 @@ class options(WebPage):  # /jo
                 u"sdt": gv.sd[u"sdt"],
                 u"mas": gv.sd[u"mas"],
                 u"mton": gv.sd[u"mton"],
-                u"mtof": gv.sd[u"mtoff"],
+                u"mtoff": gv.sd[u"mtoff"],
                 u"urs": gv.sd[u"urs"],
                 u"rso": gv.sd[u"rst"],
                 u"wl": gv.sd[u"wl"],

--- a/webpages.py
+++ b/webpages.py
@@ -269,16 +269,9 @@ class change_options(ProtectedPage):
             gv.sd["htip"] = qdict["ohtip"]
 
         for f in ["sdt", "mas", "mton", "mtoff", "wl", "lr", "tz"]:
-            if (f == "sdt"
-                or f == "mton"
-                or f == "mtoff" 
-                and qdict["o" + f] == ""             
-                ):
+            if (f in ["sdt", "mton", "mtoff"] and qdict["o" + f] == ""):
                 qdict["o" + f] = 0
-            elif (f == "wl"
-                  or f == "lr"
-                  and qdict["o" + f] == ""
-                  ):
+            elif (f in ["wl", "lr"] and qdict["o" + f] == ""):
                   qdict["o" + f] = 100
             if "o" + f in qdict:
                 if (f == "mton"


### PR DESCRIPTION
```
            if (f == "sdt"
                or f == "mton"
                or f == "mtoff" 
                and qdict["o" + f] == ""             
                ):
```
was handled as
```
            if (f == "sdt"
                or f == "mton"
                or (f == "mtoff" 
                and qdict["o" + f] == "")             
                ):
```